### PR TITLE
Add optional --scaffold_dir parameter 

### DIFF
--- a/pipelines/AssemblyPostProcesser
+++ b/pipelines/AssemblyPostProcesser
@@ -34,6 +34,9 @@ my $usage = <<__EOUSAGE__;
 #  --gene_family_search <string>   : File with a list of orthogroup identifiers for target gene families to assemble
 #                                    - requires "--scaffold" and "--method" 
 #
+#  --scaffold_dir <string>         : Optional directory path containing the scaffolds datasets
+#                                    Default: $home/data
+#
 #  --scaffold <string>             : Orthogroups or gene families proteins scaffold - required by "--gene_family_search"
 #                                    If Angiosperms clusters (version 1.0): 22Gv1.0
 #                                    If Angiosperms clusters (version 1.1): 22Gv1.1
@@ -76,6 +79,7 @@ my $transcripts;
 my $prediction_method;
 my $score_matrices;
 my $gene_family_search;
+my $scaffold_dir;
 my $scaffold;
 my $method;
 my $gap_trimming;
@@ -88,6 +92,7 @@ my $options = GetOptions (  'transcripts=s' => \$transcripts,
 	      'prediction_method=s' => \$prediction_method,
 	      'score_matrices=s' => \$score_matrices,
 	      'gene_family_search=s' => \$gene_family_search,
+	      'scaffold_dir=s' => \$scaffold_dir,
 	      'scaffold=s' => \$scaffold,
 	      'method=s' => \$method,
 	      'gap_trimming=f' => \$gap_trimming,
@@ -105,6 +110,12 @@ while (<IN>) {
 	my @F = split(/\=/, $_);
 	$utilies{$F[0]} = $F[1];
 }
+close IN;
+
+if (!($scaffold_dir)) {
+    $scaffold_dir = "$home/data"
+}
+
 my $estscan = $utilies{'estscan'};
 my $transdecoder = $utilies{'transdecoder'};
 my $genometools = $utilies{'genometools'};
@@ -545,7 +556,7 @@ sub targeted_gene_family_assembly {
 	foreach my $ortho_id (sort keys %target_ids) {
 		print "############ Target Family - Orthogroup $ortho_id ############\n\n";
 		# check if target hmm profile is present for the scaffold and method
-		if (!(-e "$home/data/$scaffold/hmms/$clustering_method/$ortho_id.hmm") or (-z "$home/data/$scaffold/hmms/$clustering_method/$ortho_id.hmm")) {
+		if (!(-e "$scaffold_dir/$scaffold/hmms/$clustering_method/$ortho_id.hmm") or (-z "$scaffold_dir/$scaffold/hmms/$clustering_method/$ortho_id.hmm")) {
 			print "HMM profile for orthogroup $ortho_id doesn't exist for $clustering_method method of scaffold $scaffold!\n\n";
 			next;
 		}
@@ -553,10 +564,10 @@ sub targeted_gene_family_assembly {
 		mkdir ($target_out_dir, 0755);
 		# hmmsearch target profile using post-processed predicted proteins - default parameters
 		if ($dereplicate) { 
-			system "$hmmsearch -E 10 --cpu $num_threads --noali --tblout $target_out_dir/temp.1.hmm -o $target_out_dir/temp.1.hmm.log $home/data/$scaffold/hmms/$clustering_method/$ortho_id.hmm $out_dir/transcripts.cleaned.nr.pep >/dev/null 2>/dev/null";
+			system "$hmmsearch -E 10 --cpu $num_threads --noali --tblout $target_out_dir/temp.1.hmm -o $target_out_dir/temp.1.hmm.log $scaffold_dir/$scaffold/hmms/$clustering_method/$ortho_id.hmm $out_dir/transcripts.cleaned.nr.pep >/dev/null 2>/dev/null";
 		}
 		else {
-			system "$hmmsearch -E 10 --cpu $num_threads --noali --tblout $target_out_dir/temp.1.hmm -o $target_out_dir/temp.1.hmm.log $home/data/$scaffold/hmms/$clustering_method/$ortho_id.hmm $out_dir/transcripts.cleaned.pep >/dev/null 2>/dev/null";
+			system "$hmmsearch -E 10 --cpu $num_threads --noali --tblout $target_out_dir/temp.1.hmm -o $target_out_dir/temp.1.hmm.log $scaffold_dir/$scaffold/hmms/$clustering_method/$ortho_id.hmm $out_dir/transcripts.cleaned.pep >/dev/null 2>/dev/null";
 		}
 		# extract corresponding primary contigs for target hits
 		my $hits = 0;
@@ -612,7 +623,7 @@ sub targeted_gene_family_assembly {
 		    open(IN, "$target_out_dir/transcripts.cleaned.nr.cds") or die "can't open $target_out_dir/transcripts.cleaned.nr.cds file\n";
 		    while(<IN>){ chomp; if (/^>(\S+)/) { $seq_id = $1; } else { s/\s+//g; $assembly_cds{$seq_id} .= $_ ; } }
 		    close IN;
-		    system "$hmmsearch -E 1e-5 --cpu $num_threads --noali --tblout $target_out_dir/temp.2.hmm -o $target_out_dir/temp.2.hmm.log $home/data/$scaffold/hmms/$clustering_method/$ortho_id.hmm $target_out_dir/transcripts.cleaned.nr.pep >/dev/null 2>/dev/null";			
+		    system "$hmmsearch -E 1e-5 --cpu $num_threads --noali --tblout $target_out_dir/temp.2.hmm -o $target_out_dir/temp.2.hmm.log $scaffold_dir/$scaffold/hmms/$clustering_method/$ortho_id.hmm $target_out_dir/transcripts.cleaned.nr.pep >/dev/null 2>/dev/null";			
 		} 
 		else {
 		    open(IN, "$target_out_dir/transcripts.cleaned.pep") or die "can't open $target_out_dir/transcripts.cleaned.pep file\n";
@@ -621,7 +632,7 @@ sub targeted_gene_family_assembly {
 		    open(IN, "$target_out_dir/transcripts.cleaned.cds") or die "can't open $target_out_dir/$transcripts.cleaned.cds file\n";
 		    while(<IN>){ chomp; if (/^>(\S+)/) { $seq_id = $1; } else { s/\s+//g; $assembly_cds{$seq_id} .= $_ ; } }
 		    close IN;
-		    system "$hmmsearch -E 1e-5 --cpu $num_threads --noali --tblout $target_out_dir/temp.2.hmm -o $target_out_dir/temp.2.hmm.log $home/data/$scaffold/hmms/$clustering_method/$ortho_id.hmm $target_out_dir/transcripts.cleaned.pep >/dev/null 2>/dev/null";								
+		    system "$hmmsearch -E 1e-5 --cpu $num_threads --noali --tblout $target_out_dir/temp.2.hmm -o $target_out_dir/temp.2.hmm.log $scaffold_dir/$scaffold/hmms/$clustering_method/$ortho_id.hmm $target_out_dir/transcripts.cleaned.pep >/dev/null 2>/dev/null";								
 		}	
 		# compute transcript orthogroup coverage
 		$hits = 0;
@@ -635,7 +646,7 @@ sub targeted_gene_family_assembly {
 			system "rm -r $target_out_dir";
 			next;
 		}
-		system "$mafft --add $target_out_dir/temp.2.hmm.pep $home/data/$scaffold/alns/$clustering_method/$ortho_id.aln > $target_out_dir/temp.2.hmm.pep.aln 2>/dev/null";
+		system "$mafft --add $target_out_dir/temp.2.hmm.pep $scaffold_dir/$scaffold/alns/$clustering_method/$ortho_id.aln > $target_out_dir/temp.2.hmm.pep.aln 2>/dev/null";
 		unless ($gap_trimming) { $gap_trimming = 0.1; } 
 		system "$trimal -in $target_out_dir/temp.2.hmm.pep.aln -out $target_out_dir/temp.2.hmm.pep.aln.trim -gt $gap_trimming >/dev/null 2>/dev/null";
 		open(IN, "$target_out_dir/temp.2.hmm.pep.aln.trim") or die "can't open $target_out_dir/temp.2.hmm.pep.aln.trim file\n";

--- a/pipelines/GeneFamilyClassifier
+++ b/pipelines/GeneFamilyClassifier
@@ -39,6 +39,9 @@ my $usage = <<__EOUSAGE__;
 # # # # # # # # # # # # # # # # # # 
 #  Others Options:
 #
+#  --scaffold_dir <string>         : Optional directory path containing the scaffolds datasets
+#                                    Default: $home/data
+#
 #  --num_threads <int>             : number of threads (CPUs) to used for HMMScan, BLASTP, and MAFFT
 #                                    Default: 1 
 #
@@ -73,6 +76,7 @@ my $proteins;
 my $scaffold;
 my $method;
 my $classifier;
+my $scaffold_dir;
 my $num_threads;
 my $super_orthogroups;
 my $single_copy_custom;
@@ -85,6 +89,7 @@ my $options = GetOptions (  'proteins=s' => \$proteins,
               'scaffold=s' => \$scaffold,
               'method=s' => \$method,
               'classifier=s' => \$classifier,
+              'scaffold_dir=s' => \$scaffold_dir,
               'num_threads=i' => \$num_threads,
               'super_orthogroups=s' => \$super_orthogroups,
               'single_copy_custom' => \$single_copy_custom,
@@ -103,6 +108,11 @@ while (<IN>) {
 	$utilies{$F[0]} = $F[1];
 }
 close IN;
+
+if (!($scaffold_dir)) {
+    $scaffold_dir = "$home/data"
+}
+
 my $blastp = $utilies{'blastp'};
 my $hmmscan = $utilies{'hmmscan'};
               
@@ -169,14 +179,14 @@ sub sort_sequences {
 	if ( (!$super_orthogroups) or ($super_orthogroups ne "min_evalue") or ($super_orthogroups ne "avg_evalue") ) { $super_orthogroups = "min_evalue" } 
 	if ( ($classifier eq "blastp") or ($classifier eq "both") ) {
 		print "-- ".localtime()." - Running BLASTP\n\n";
-		system "$blastp -db_soft_mask 21 -outfmt 6 -evalue 1e-5 -num_threads $num_threads -query $proteins -db $home/data/$scaffold/db/blast/$method -out $dirname/proteins.blastp.$scaffold  >/dev/null 2>/dev/null";
+		system "$blastp -db_soft_mask 21 -outfmt 6 -evalue 1e-5 -num_threads $num_threads -query $proteins -db $scaffold_dir/$scaffold/db/blast/$method -out $dirname/proteins.blastp.$scaffold  >/dev/null 2>/dev/null";
 		print "-- ".localtime()." - Getting best BLASTP hits\n\n";
 		my $results = "proteins.blastp.$scaffold";
 		get_best_blastp_orthos ( $classifier, $results, $dirname, $scaffold, $method, $super_orthogroups, $home );
 	}
 	if ( ($classifier eq "hmmscan") or ($classifier eq "both") ) {
 		print "-- ".localtime()." - Running HMMScan\n\n";
-		system "$hmmscan -E 1e-5 --cpu $num_threads --noali --tblout $dirname/proteins.hmmscan.$scaffold -o $dirname/hmmscan.log $home/data/$scaffold/db/hmm/$method $proteins >/dev/null 2>/dev/null";
+		system "$hmmscan -E 1e-5 --cpu $num_threads --noali --tblout $dirname/proteins.hmmscan.$scaffold -o $dirname/hmmscan.log $scaffold_dir/$scaffold/db/hmm/$method $proteins >/dev/null 2>/dev/null";
 		print "-- ".localtime()." - Getting best HMMScan hits\n\n";
 		my $results = "proteins.hmmscan.$scaffold";
 		get_best_hmmscan_orthos ( $classifier, $results, $dirname, $scaffold, $method, $super_orthogroups, $home );
@@ -203,7 +213,7 @@ sub  get_best_blastp_orthos {
     	}
 	} 
 	close IN;
-	open (IN, "$home/data/$scaffold/annot/$method.list") or die "can't open $home/data/$scaffold/annot/$method.list file\n";
+	open (IN, "$scaffold_dir/$scaffold/annot/$method.list") or die "can't open $scaffold_dir/$scaffold/annot/$method.list file\n";
 	while (<IN>) {
 		chomp;
 		my @F=split(/\t/, $_);
@@ -303,7 +313,7 @@ sub get_annot_summary {
 	my ( $orthogroup_assignment, $dirname, $scaffold, $method, $super_orthogroups, $home ) = @_;
 	my %annot;
 	open (OUT, ">$dirname/$orthogroup_assignment.summary") or die "can't open $dirname/$orthogroup_assignment.summary file\n";	
-	open (IN, "$home/data/$scaffold/annot/$method.$super_orthogroups.summary") or die "can't open $home/data/$scaffold/annot/$method.$super_orthogroups.summary file\n";
+	open (IN, "$scaffold_dir/$scaffold/annot/$method.$super_orthogroups.summary") or die "can't open $scaffold_dir/$scaffold/annot/$method.$super_orthogroups.summary file\n";
 	while (<IN>) {
 		chomp;
 		if ($_ =~ /^Orthogroup/) { print OUT "Gene ID\t$_\n"; next; }

--- a/pipelines/PhylogenomicsAnalysis
+++ b/pipelines/PhylogenomicsAnalysis
@@ -90,6 +90,9 @@ my $usage = <<__EOUSAGE__;
 # # # # # # # # # # # # # # # # # # 
 #  Others Options:
 #
+#  --scaffold_dir <string>         : Optional directory path containing the scaffolds datasets
+#                                    Default: $home/data
+#
 #  --num_threads <int>             : number of threads (CPUs) to assign to external utilities (MAFFT, PASTA, and RAxML)
 #                                    Default: 1 
 #
@@ -130,6 +133,7 @@ my $bootstrap_replicates;
 my $automated_trimming;
 my $gap_trimming;
 my $remove_sequences;
+my $scaffold_dir;
 my $num_threads;
 my $max_memory;
 my $pasta_iter_limit;
@@ -152,6 +156,7 @@ my $options = GetOptions (  'orthogroup_faa=s' => \$orthogroup_faa,
               'automated_trimming' => \$automated_trimming,
               'gap_trimming=f' => \$gap_trimming,
               'remove_sequences=f' => \$remove_sequences,
+              'scaffold_dir=s' => \$scaffold_dir,
               'num_threads=i' => \$num_threads,
               'max_memory=i' => \$max_memory,
               'pasta_iter_limit=i'=> \$pasta_iter_limit,
@@ -167,6 +172,11 @@ while (<IN>) {
 	$utilies{$F[0]} = $F[1];
 }
 close IN;
+
+if (!($scaffold_dir)) {
+    $scaffold_dir = "$home/data"
+}
+
 my $mafft = $utilies{'mafft'};
 my $pasta = $utilies{'pasta'};
 my $trimal = $utilies{'trimal'};
@@ -266,9 +276,9 @@ sub get_orthogroup_fasta {
 		die "Exiting...!\nOrthogroup classification protein and CDS fasta files not equivalent in $orthogroup_faa directory\n\n";
 	}	
 	foreach my $ortho_id (keys %pep) { 
-		system "cat $home/data/$scaffold/fasta/$method/$ortho_id.faa $orthogroup_faa/$ortho_id.faa > $orthogroups_fasta/$ortho_id.faa";
+		system "cat $scaffold_dir/$scaffold/fasta/$method/$ortho_id.faa $orthogroup_faa/$ortho_id.faa > $orthogroups_fasta/$ortho_id.faa";
 		if ($orthogroup_fna and $cds{$ortho_id}) {
-			system "cat $home/data/$scaffold/fasta/$method/$ortho_id.fna $orthogroup_faa/$ortho_id.fna > $orthogroups_fasta/$ortho_id.fna";
+			system "cat $scaffold_dir/$scaffold/fasta/$method/$ortho_id.fna $orthogroup_faa/$ortho_id.fna > $orthogroups_fasta/$ortho_id.fna";
 		}
 	} 	
 }
@@ -294,7 +304,7 @@ sub create_orthogroup_alignments {
 			system "$mafft --maxiterate 1000 --thread $num_threads --localpair $orthogroups_fasta/$ortho_id.faa > $orthogroups_aln/$ortho_id.faa.aln 2>/dev/null"; 
 		}
 		if ($add_alignments) {
-			system "$mafft --add $orthogroup_faa/$ortho_id.faa $home/data/$scaffold/alns/$method/$ortho_id.aln > $orthogroups_aln/$ortho_id.faa.aln 2>/dev/null";
+			system "$mafft --add $orthogroup_faa/$ortho_id.faa $scaffold_dir/$scaffold/alns/$method/$ortho_id.aln > $orthogroups_aln/$ortho_id.faa.aln 2>/dev/null";
 		}
 		if ($pasta_alignments) {
 			my $pasta_temp = "$dirname/pasta_temp";


### PR DESCRIPTION
that, if used, will override default setting of $home/data.  This allows the PlantTribes pipelines to be functional within and environment that has the very large scaffolds datasets installed in a location outside of the PlantTribes installation directory structure.