### PR TITLE
Allow for not overriding the environment

### DIFF
--- a/pipelines/AssemblyPostProcesser
+++ b/pipelines/AssemblyPostProcesser
@@ -62,6 +62,9 @@ my $usage = <<__EOUSAGE__;
 #  --num_threads <int>             : number of threads (CPUs) - only required for targeted gene family assembly
 #                                    Default: 1
 #
+#  --no_config_override            : Do not override values defined in the environment with values defined in
+#                                    $home/config/plantTribes.config.
+#
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #  Example Usage:
 #
@@ -87,6 +90,19 @@ my $strand_specific;
 my $dereplicate;
 my $min_length;
 my $num_threads;
+my $no_config_override;
+
+# Values that can either be retrieved from
+# $home/config/plantTribes.config or located
+# on $PATH using --no_config_override.
+my %utilies;
+my $estscan;
+my $transdecoder;
+my $genometools;
+my $hmmsearch;
+my $cap3;
+my $mafft;
+my $trimal;
 
 my $options = GetOptions (  'transcripts=s' => \$transcripts,
 	      'prediction_method=s' => \$prediction_method,
@@ -99,30 +115,42 @@ my $options = GetOptions (  'transcripts=s' => \$transcripts,
 	      'strand_specific' => \$strand_specific,
 	      'dereplicate' => \$dereplicate,
 	      'min_length=i' => \$min_length,
-	      'num_threads=i' => \$num_threads
+	      'num_threads=i' => \$num_threads,
+	      'no_config_override' => \$no_config_override
 	      );
 
-my %utilies;
-open (IN, "$home/config/plantTribes.config") or die "can't open $home/config/plantTribes.config file\n";
-while (<IN>) {
-	chomp;
-	if ($_ !~ /^\w+/) { next; }
-	my @F = split(/\=/, $_);
-	$utilies{$F[0]} = $F[1];
+# Should hmmsearch actually be hmmscan?
+if ($no_config_override) {
+    $estscan = 'ESTScan';
+    $transdecoder = 'TransDecoder.LongOrfs';
+    $genometools = 'gt';
+    $hmmsearch = 'hmmsearch';
+    $cap3 = 'cap3';
+    $mafft = 'mafft';
+    $trimal = 'trimal';
 }
-close IN;
+else {
+    open (IN, "$home/config/plantTribes.config") or die "can't open $home/config/plantTribes.config file\n";
+    while (<IN>) {
+	   chomp;
+	   if ($_ !~ /^\w+/) { next; }
+	   my @F = split(/\=/, $_);
+	   $utilies{$F[0]} = $F[1];
+    }
+    close IN;
+
+    $estscan = $utilies{'estscan'};
+    $transdecoder = $utilies{'transdecoder'};
+    $genometools = $utilies{'genometools'};
+    $hmmsearch = $utilies{'hmmsearch'};
+    $cap3 = $utilies{'cap3'};
+    $mafft = $utilies{'mafft'};
+    $trimal = $utilies{'trimal'};
+}
 
 if (!($scaffold_dir)) {
     $scaffold_dir = "$home/data"
 }
-
-my $estscan = $utilies{'estscan'};
-my $transdecoder = $utilies{'transdecoder'};
-my $genometools = $utilies{'genometools'};
-my $hmmsearch = $utilies{'hmmsearch'};
-my $cap3 = $utilies{'cap3'};
-my $mafft = $utilies{'mafft'};
-my $trimal = $utilies{'trimal'};
 
 # validate options
 my %scaffolds = ("12Gv1.0", "Monocots clusters (version 1.0)",  "22Gv1.0", "Angiosperms clusters (version 1.0)",

--- a/pipelines/GeneFamilyClassifier
+++ b/pipelines/GeneFamilyClassifier
@@ -61,6 +61,9 @@ my $usage = <<__EOUSAGE__;
 #                                    
 #  --coding_sequences <string>     : Corresponding coding sequences (CDS) fasta file (cds.fasta)
 #
+#  --no_config_override            : Do not override values defined in the environment with values defined in
+#                                    $home/config/plantTribes.config.
+#
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #  Example Usage:
 #
@@ -84,6 +87,14 @@ my $single_copy_taxa;
 my $taxa_present;
 my $orthogroup_fasta;
 my $coding_sequences;
+my $no_config_override;
+
+# Values that can either be retrieved from
+# $home/config/plantTribes.config or located
+# on $PATH using --no_config_override.
+my %utilies;
+my $blastp;
+my $hmmscan;
 
 my $options = GetOptions (  'proteins=s' => \$proteins,
               'scaffold=s' => \$scaffold,
@@ -97,24 +108,30 @@ my $options = GetOptions (  'proteins=s' => \$proteins,
               'taxa_present=i' => \$taxa_present,
               'orthogroup_fasta' => \$orthogroup_fasta,
               'coding_sequences=s' => \$coding_sequences,
+              'no_config_override' => \$no_config_override
               );
-              
-my %utilies;
-open (IN, "$home/config/plantTribes.config") or die "can't open $home/config/plantTribes.config file\n";
-while (<IN>) {
-	chomp;
-	if ($_ !~ /^\w+/) { next; }
-	my @F = split(/\=/, $_);
-	$utilies{$F[0]} = $F[1];
+
+if ($no_config_override) {
+    $blastp = 'blastp';
+    $hmmscan = 'hmmscan';
 }
-close IN;
+else {
+    open (IN, "$home/config/plantTribes.config") or die "can't open $home/config/plantTribes.config file\n";
+    while (<IN>) {
+	   chomp;
+	   if ($_ !~ /^\w+/) { next; }
+	   my @F = split(/\=/, $_);
+	   $utilies{$F[0]} = $F[1];
+    }
+    close IN;
+
+    $blastp = $utilies{'blastp'};
+    $hmmscan = $utilies{'hmmscan'};
+}
 
 if (!($scaffold_dir)) {
     $scaffold_dir = "$home/data"
 }
-
-my $blastp = $utilies{'blastp'};
-my $hmmscan = $utilies{'hmmscan'};
               
 # validate options            
 my %scaffolds = ("12Gv1.0", "Monocots clusters (version 1.0)",  "22Gv1.0", "Angiosperms clusters (version 1.0)",

--- a/pipelines/PhylogenomicsAnalysis
+++ b/pipelines/PhylogenomicsAnalysis
@@ -101,9 +101,18 @@ my $usage = <<__EOUSAGE__;
 # 
 #  --pasta_iter_limit <int>        : Maximum number of iteration that the PASTA algorithm will run - requires "--pasta_alignments" 
 #                                    Default: 3
-#                                   
+#
+#  --pasta_script_path <string>    : Optional path to the location of the run_pasta.py script. which is used for running PASTA
+#                                    from the command line (useful since the script is a .py file).  Using this will override
+#                                    the default defined in $home/config/plantTribes.config, and it will complement the behavior
+#                                    that results from using --no_config_override by replacing the program default with the
+#                                    received value.
+#
 #  --orthogroup_fna                : Corresponding gene family classification orthogroups CDS fasta files. Files should be in the
-#                                    same directory with input orthogroups protein fasta files. 
+#                                    same directory with input orthogroups protein fasta files.
+#
+#  --no_config_override            : Do not override values defined in the environment with values defined in
+#                                    $home/config/plantTribes.config.
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #  Example Usage:
@@ -137,7 +146,19 @@ my $scaffold_dir;
 my $num_threads;
 my $max_memory;
 my $pasta_iter_limit;
+my $pasta_script_path;
 my $orthogroup_fna;
+my $no_config_override;
+
+# Values that can either be retrieved from
+# $home/config/plantTribes.config or located
+# on $PATH using --no_config_override.
+my %utilies;
+my $mafft;
+my $pasta;
+my $trimal;
+my $raxml;
+my $fasttree;
 
 my $options = GetOptions (  'orthogroup_faa=s' => \$orthogroup_faa,
               'scaffold=s' => \$scaffold,
@@ -160,28 +181,43 @@ my $options = GetOptions (  'orthogroup_faa=s' => \$orthogroup_faa,
               'num_threads=i' => \$num_threads,
               'max_memory=i' => \$max_memory,
               'pasta_iter_limit=i'=> \$pasta_iter_limit,
+              'pasta_script_path=s'=>\$pasta_script_path,
               'orthogroup_fna' => \$orthogroup_fna,
+              'no_config_override' => \$no_config_override
               );
-              
-my %utilies;
-open (IN, "$home/config/plantTribes.config") or die "can't open $home/config/plantTribes.config file\n";
-while (<IN>) {
-	chomp;
-	if ($_ !~ /^\w+/) { next; }
-	my @F = split(/\=/, $_);
-	$utilies{$F[0]} = $F[1];
+
+if ($no_config_override) {
+    $mafft = 'mafft';
+    $pasta = 'run_pasta.py';
+    $trimal = 'trimal';
+    $raxml = 'raxmlHPC-PTHREADS-SSE3';
+    $fasttree = 'FastTreeMP';
 }
-close IN;
+else {
+    open (IN, "$home/config/plantTribes.config") or die "can't open $home/config/plantTribes.config file\n";
+    while (<IN>) {
+	   chomp;
+	   if ($_ !~ /^\w+/) { next; }
+	   my @F = split(/\=/, $_);
+	   $utilies{$F[0]} = $F[1];
+    }
+    close IN;
+
+    $mafft = $utilies{'mafft'};
+    $pasta = $utilies{'pasta'};
+    $trimal = $utilies{'trimal'};
+    $raxml = $utilies{'raxml'};
+    $fasttree = $utilies{'fasttree'};
+}
+
+if ($pasta_script_path) {
+    # Use the specified path to the run_pasta.py script.
+    $pasta = $pasta_script_path;
+}
 
 if (!($scaffold_dir)) {
     $scaffold_dir = "$home/data"
 }
-
-my $mafft = $utilies{'mafft'};
-my $pasta = $utilies{'pasta'};
-my $trimal = $utilies{'trimal'};
-my $raxml = $utilies{'raxml'};
-my $fasttree = $utilies{'fasttree'};
 
 # validate options
 my %scaffolds = ("12Gv1.0", "Monocots clusters (version 1.0)",  "22Gv1.0", "Angiosperms clusters (version 1.0)",


### PR DESCRIPTION
with values in the PlantTribes.config file.

@ewafula This PR is fully backward compatible with your earlier versions of these pipelines. 

I have added an additional optional parameter --no_config_override to each of the pipelines which, if used, will not set parameter values for 3rd party binaries (e.g., mafft, ESTScan, etc) by reading the PlantTribes.config file.  This is beneficial if these binaries can be located on the environment's $PATH.

For the PhylogenomicsAnalysis pipeline, I have added another additional optional parameter --pasta_script_path which if used, will set the value of the program's $pasta variable to the received path.  In many cases this is necessary since this is a Python script (i.e., run_pasta.py) and, when executing with Python within the pipeline code, the full path must be used.