### PR TITLE
Remove the recently added --no_config_override option

### DIFF
--- a/pipelines/AssemblyPostProcesser
+++ b/pipelines/AssemblyPostProcesser
@@ -62,9 +62,6 @@ my $usage = <<__EOUSAGE__;
 #  --num_threads <int>             : number of threads (CPUs) - only required for targeted gene family assembly
 #                                    Default: 1
 #
-#  --no_config_override            : Do not override values defined in the environment with values defined in
-#                                    $home/config/plantTribes.config.
-#
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #  Example Usage:
 #
@@ -90,19 +87,6 @@ my $strand_specific;
 my $dereplicate;
 my $min_length;
 my $num_threads;
-my $no_config_override;
-
-# Values that can either be retrieved from
-# $home/config/plantTribes.config or located
-# on $PATH using --no_config_override.
-my %utilies;
-my $estscan;
-my $transdecoder;
-my $genometools;
-my $hmmsearch;
-my $cap3;
-my $mafft;
-my $trimal;
 
 my $options = GetOptions (  'transcripts=s' => \$transcripts,
 	      'prediction_method=s' => \$prediction_method,
@@ -115,42 +99,30 @@ my $options = GetOptions (  'transcripts=s' => \$transcripts,
 	      'strand_specific' => \$strand_specific,
 	      'dereplicate' => \$dereplicate,
 	      'min_length=i' => \$min_length,
-	      'num_threads=i' => \$num_threads,
-	      'no_config_override' => \$no_config_override
+	      'num_threads=i' => \$num_threads
 	      );
 
-# Should hmmsearch actually be hmmscan?
-if ($no_config_override) {
-    $estscan = 'ESTScan';
-    $transdecoder = 'TransDecoder.LongOrfs';
-    $genometools = 'gt';
-    $hmmsearch = 'hmmsearch';
-    $cap3 = 'cap3';
-    $mafft = 'mafft';
-    $trimal = 'trimal';
+my %utilies;
+open (IN, "$home/config/plantTribes.config") or die "can't open $home/config/plantTribes.config file\n";
+while (<IN>) {
+	chomp;
+	if ($_ !~ /^\w+/) { next; }
+	my @F = split(/\=/, $_);
+	$utilies{$F[0]} = $F[1];
 }
-else {
-    open (IN, "$home/config/plantTribes.config") or die "can't open $home/config/plantTribes.config file\n";
-    while (<IN>) {
-	   chomp;
-	   if ($_ !~ /^\w+/) { next; }
-	   my @F = split(/\=/, $_);
-	   $utilies{$F[0]} = $F[1];
-    }
-    close IN;
-
-    $estscan = $utilies{'estscan'};
-    $transdecoder = $utilies{'transdecoder'};
-    $genometools = $utilies{'genometools'};
-    $hmmsearch = $utilies{'hmmsearch'};
-    $cap3 = $utilies{'cap3'};
-    $mafft = $utilies{'mafft'};
-    $trimal = $utilies{'trimal'};
-}
+close IN;
 
 if (!($scaffold_dir)) {
     $scaffold_dir = "$home/data"
 }
+
+my $estscan = $utilies{'estscan'};
+my $transdecoder = $utilies{'transdecoder'};
+my $genometools = $utilies{'genometools'};
+my $hmmsearch = $utilies{'hmmsearch'};
+my $cap3 = $utilies{'cap3'};
+my $mafft = $utilies{'mafft'};
+my $trimal = $utilies{'trimal'};
 
 # validate options
 my %scaffolds = ("12Gv1.0", "Monocots clusters (version 1.0)",  "22Gv1.0", "Angiosperms clusters (version 1.0)",

--- a/pipelines/GeneFamilyClassifier
+++ b/pipelines/GeneFamilyClassifier
@@ -61,9 +61,6 @@ my $usage = <<__EOUSAGE__;
 #                                    
 #  --coding_sequences <string>     : Corresponding coding sequences (CDS) fasta file (cds.fasta)
 #
-#  --no_config_override            : Do not override values defined in the environment with values defined in
-#                                    $home/config/plantTribes.config.
-#
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #  Example Usage:
 #
@@ -87,14 +84,6 @@ my $single_copy_taxa;
 my $taxa_present;
 my $orthogroup_fasta;
 my $coding_sequences;
-my $no_config_override;
-
-# Values that can either be retrieved from
-# $home/config/plantTribes.config or located
-# on $PATH using --no_config_override.
-my %utilies;
-my $blastp;
-my $hmmscan;
 
 my $options = GetOptions (  'proteins=s' => \$proteins,
               'scaffold=s' => \$scaffold,
@@ -108,30 +97,24 @@ my $options = GetOptions (  'proteins=s' => \$proteins,
               'taxa_present=i' => \$taxa_present,
               'orthogroup_fasta' => \$orthogroup_fasta,
               'coding_sequences=s' => \$coding_sequences,
-              'no_config_override' => \$no_config_override
               );
-
-if ($no_config_override) {
-    $blastp = 'blastp';
-    $hmmscan = 'hmmscan';
+              
+my %utilies;
+open (IN, "$home/config/plantTribes.config") or die "can't open $home/config/plantTribes.config file\n";
+while (<IN>) {
+	chomp;
+	if ($_ !~ /^\w+/) { next; }
+	my @F = split(/\=/, $_);
+	$utilies{$F[0]} = $F[1];
 }
-else {
-    open (IN, "$home/config/plantTribes.config") or die "can't open $home/config/plantTribes.config file\n";
-    while (<IN>) {
-	   chomp;
-	   if ($_ !~ /^\w+/) { next; }
-	   my @F = split(/\=/, $_);
-	   $utilies{$F[0]} = $F[1];
-    }
-    close IN;
-
-    $blastp = $utilies{'blastp'};
-    $hmmscan = $utilies{'hmmscan'};
-}
+close IN;
 
 if (!($scaffold_dir)) {
     $scaffold_dir = "$home/data"
 }
+
+my $blastp = $utilies{'blastp'};
+my $hmmscan = $utilies{'hmmscan'};
               
 # validate options            
 my %scaffolds = ("12Gv1.0", "Monocots clusters (version 1.0)",  "22Gv1.0", "Angiosperms clusters (version 1.0)",

--- a/pipelines/PhylogenomicsAnalysis
+++ b/pipelines/PhylogenomicsAnalysis
@@ -104,15 +104,10 @@ my $usage = <<__EOUSAGE__;
 #
 #  --pasta_script_path <string>    : Optional path to the location of the run_pasta.py script. which is used for running PASTA
 #                                    from the command line (useful since the script is a .py file).  Using this will override
-#                                    the default defined in $home/config/plantTribes.config, and it will complement the behavior
-#                                    that results from using --no_config_override by replacing the program default with the
-#                                    received value.
+#                                    the default defined in $home/config/plantTribes.
 #
 #  --orthogroup_fna                : Corresponding gene family classification orthogroups CDS fasta files. Files should be in the
-#                                    same directory with input orthogroups protein fasta files.
-#
-#  --no_config_override            : Do not override values defined in the environment with values defined in
-#                                    $home/config/plantTribes.config.
+#                                    same directory with input orthogroups protein fasta files. 
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #  Example Usage:
@@ -145,20 +140,10 @@ my $remove_sequences;
 my $scaffold_dir;
 my $num_threads;
 my $max_memory;
+my $pasta;
 my $pasta_iter_limit;
 my $pasta_script_path;
 my $orthogroup_fna;
-my $no_config_override;
-
-# Values that can either be retrieved from
-# $home/config/plantTribes.config or located
-# on $PATH using --no_config_override.
-my %utilies;
-my $mafft;
-my $pasta;
-my $trimal;
-my $raxml;
-my $fasttree;
 
 my $options = GetOptions (  'orthogroup_faa=s' => \$orthogroup_faa,
               'scaffold=s' => \$scaffold,
@@ -183,41 +168,33 @@ my $options = GetOptions (  'orthogroup_faa=s' => \$orthogroup_faa,
               'pasta_iter_limit=i'=> \$pasta_iter_limit,
               'pasta_script_path=s'=>\$pasta_script_path,
               'orthogroup_fna' => \$orthogroup_fna,
-              'no_config_override' => \$no_config_override
               );
 
-if ($no_config_override) {
-    $mafft = 'mafft';
-    $pasta = 'run_pasta.py';
-    $trimal = 'trimal';
-    $raxml = 'raxmlHPC-PTHREADS-SSE3';
-    $fasttree = 'FastTreeMP';
+my %utilies;
+open (IN, "$home/config/plantTribes.config") or die "can't open $home/config/plantTribes.config file\n";
+while (<IN>) {
+	chomp;
+	if ($_ !~ /^\w+/) { next; }
+	my @F = split(/\=/, $_);
+	$utilies{$F[0]} = $F[1];
 }
-else {
-    open (IN, "$home/config/plantTribes.config") or die "can't open $home/config/plantTribes.config file\n";
-    while (<IN>) {
-	   chomp;
-	   if ($_ !~ /^\w+/) { next; }
-	   my @F = split(/\=/, $_);
-	   $utilies{$F[0]} = $F[1];
-    }
-    close IN;
+close IN;
 
-    $mafft = $utilies{'mafft'};
-    $pasta = $utilies{'pasta'};
-    $trimal = $utilies{'trimal'};
-    $raxml = $utilies{'raxml'};
-    $fasttree = $utilies{'fasttree'};
+if (!($scaffold_dir)) {
+    $scaffold_dir = "$home/data"
 }
 
 if ($pasta_script_path) {
     # Use the specified path to the run_pasta.py script.
     $pasta = $pasta_script_path;
+} else {
+    $pasta = $utilies{'pasta'};
 }
 
-if (!($scaffold_dir)) {
-    $scaffold_dir = "$home/data"
-}
+my $mafft = $utilies{'mafft'};
+my $trimal = $utilies{'trimal'};
+my $raxml = $utilies{'raxml'};
+my $fasttree = $utilies{'fasttree'};
 
 # validate options
 my %scaffolds = ("12Gv1.0", "Monocots clusters (version 1.0)",  "22Gv1.0", "Angiosperms clusters (version 1.0)",


### PR DESCRIPTION
@ewafula I have tested all 3 pipelines with the changes in this PR.  This PR is backward compatible, with the exception of my previous merge into you code.  This PR removes the --no_cache_override option I recently added.  I agree with you that this option is not very useful, and may actually be confusing.  Sorry, I must not have been thinking clearly when I added this.  :( 

This PR does keep the --pasta_script_path option, which is only needed in the PhylogenomicsAnalysis pipeline.  The Galaxy wrapper requires this option, and I think it would be useful for environments outside of Galaxy that may not use your PlantTribes.config file to set these values.  I hope this is ok.