### PR TITLE
Fix perl declaration

### DIFF
--- a/pipelines/PhylogenomicsAnalysis
+++ b/pipelines/PhylogenomicsAnalysis
@@ -1,4 +1,4 @@
-#!/usr/bin/env /usr/bin/perl
+#!/usr/bin/env perl
 # Author: Eric Wafula
 # Email: ekw10@psu.edu
 # Institution: Penn State University, Biology Dept, Claude dePamphilis Lab


### PR DESCRIPTION
@ewafula Here's a fix for your Perl declaration in your PhylogenomisAnalysis pipeline.  Looking at your repo history, this issue has been there for a while.  It doesn't pose problems locally, but it produces errors when tested within the github travis CI framework.  We'll need another repo release tag for this fix, but if you can get the KaKsAnalysis pipeline done next week, we can probably just wait and create a new tag for both.