### PR TITLE
Eliminate --scaffold_dir parameter

### DIFF
--- a/pipelines/AssemblyPostProcesser
+++ b/pipelines/AssemblyPostProcesser
@@ -6,6 +6,8 @@
 
 use strict;
 use warnings;
+use File::Spec;
+use File::Basename;
 use Getopt::Long qw(:config no_ignore_case);
 use FindBin;
 
@@ -33,9 +35,6 @@ my $usage = <<__EOUSAGE__;
 #
 #  --gene_family_search <string>   : File with a list of orthogroup identifiers for target gene families to assemble
 #                                    - requires "--scaffold" and "--method" 
-#
-#  --scaffold_dir <string>         : Optional directory path containing the scaffolds datasets
-#                                    Default: $home/data
 #
 #  --scaffold <string>             : Orthogroups or gene families proteins scaffold - required by "--gene_family_search"
 #                                    If Angiosperms clusters (version 1.0): 22Gv1.0
@@ -92,7 +91,6 @@ my $options = GetOptions (  'transcripts=s' => \$transcripts,
 	      'prediction_method=s' => \$prediction_method,
 	      'score_matrices=s' => \$score_matrices,
 	      'gene_family_search=s' => \$gene_family_search,
-	      'scaffold_dir=s' => \$scaffold_dir,
 	      'scaffold=s' => \$scaffold,
 	      'method=s' => \$method,
 	      'gap_trimming=f' => \$gap_trimming,
@@ -112,8 +110,11 @@ while (<IN>) {
 }
 close IN;
 
-if (!($scaffold_dir)) {
-    $scaffold_dir = "$home/data"
+if (File::Spec->file_name_is_absolute($scaffold)) {
+    $scaffold_dir = $scaffold;
+    $scaffold = basename($scaffold);
+} else {
+    $scaffold_dir = "$home/data/$scaffold";
 }
 
 my $estscan = $utilies{'estscan'};
@@ -566,7 +567,7 @@ sub targeted_gene_family_assembly {
 	foreach my $ortho_id (sort keys %target_ids) {
 		print "############ Target Family - Orthogroup $ortho_id ############\n\n";
 		# check if target hmm profile is present for the scaffold and method
-		if (!(-e "$scaffold_dir/$scaffold/hmms/$clustering_method/$ortho_id.hmm") or (-z "$scaffold_dir/$scaffold/hmms/$clustering_method/$ortho_id.hmm")) {
+		if (!(-e "$scaffold_dir/hmms/$clustering_method/$ortho_id.hmm") or (-z "$scaffold_dir/hmms/$clustering_method/$ortho_id.hmm")) {
 			print "HMM profile for orthogroup $ortho_id doesn't exist for $clustering_method method of scaffold $scaffold!\n\n";
 			next;
 		}
@@ -574,10 +575,10 @@ sub targeted_gene_family_assembly {
 		mkdir ($target_out_dir, 0755);
 		# hmmsearch target profile using post-processed predicted proteins - default parameters
 		if ($dereplicate) { 
-			system "$hmmsearch -E 10 --cpu $num_threads --noali --tblout $target_out_dir/temp.1.hmm -o $target_out_dir/temp.1.hmm.log $scaffold_dir/$scaffold/hmms/$clustering_method/$ortho_id.hmm $out_dir/transcripts.cleaned.nr.pep >/dev/null 2>/dev/null";
+			system "$hmmsearch -E 10 --cpu $num_threads --noali --tblout $target_out_dir/temp.1.hmm -o $target_out_dir/temp.1.hmm.log $scaffold_dir/hmms/$clustering_method/$ortho_id.hmm $out_dir/transcripts.cleaned.nr.pep >/dev/null 2>/dev/null";
 		}
 		else {
-			system "$hmmsearch -E 10 --cpu $num_threads --noali --tblout $target_out_dir/temp.1.hmm -o $target_out_dir/temp.1.hmm.log $scaffold_dir/$scaffold/hmms/$clustering_method/$ortho_id.hmm $out_dir/transcripts.cleaned.pep >/dev/null 2>/dev/null";
+			system "$hmmsearch -E 10 --cpu $num_threads --noali --tblout $target_out_dir/temp.1.hmm -o $target_out_dir/temp.1.hmm.log $scaffold_dir/hmms/$clustering_method/$ortho_id.hmm $out_dir/transcripts.cleaned.pep >/dev/null 2>/dev/null";
 		}
 		# extract corresponding primary contigs for target hits
 		my $hits = 0;
@@ -633,7 +634,7 @@ sub targeted_gene_family_assembly {
 		    open(IN, "$target_out_dir/transcripts.cleaned.nr.cds") or die "can't open $target_out_dir/transcripts.cleaned.nr.cds file\n";
 		    while(<IN>){ chomp; if (/^>(\S+)/) { $seq_id = $1; } else { s/\s+//g; $assembly_cds{$seq_id} .= $_ ; } }
 		    close IN;
-		    system "$hmmsearch -E 1e-5 --cpu $num_threads --noali --tblout $target_out_dir/temp.2.hmm -o $target_out_dir/temp.2.hmm.log $scaffold_dir/$scaffold/hmms/$clustering_method/$ortho_id.hmm $target_out_dir/transcripts.cleaned.nr.pep >/dev/null 2>/dev/null";			
+		    system "$hmmsearch -E 1e-5 --cpu $num_threads --noali --tblout $target_out_dir/temp.2.hmm -o $target_out_dir/temp.2.hmm.log $scaffold_dir/hmms/$clustering_method/$ortho_id.hmm $target_out_dir/transcripts.cleaned.nr.pep >/dev/null 2>/dev/null";			
 		} 
 		else {
 		    open(IN, "$target_out_dir/transcripts.cleaned.pep") or die "can't open $target_out_dir/transcripts.cleaned.pep file\n";
@@ -642,7 +643,7 @@ sub targeted_gene_family_assembly {
 		    open(IN, "$target_out_dir/transcripts.cleaned.cds") or die "can't open $target_out_dir/$transcripts.cleaned.cds file\n";
 		    while(<IN>){ chomp; if (/^>(\S+)/) { $seq_id = $1; } else { s/\s+//g; $assembly_cds{$seq_id} .= $_ ; } }
 		    close IN;
-		    system "$hmmsearch -E 1e-5 --cpu $num_threads --noali --tblout $target_out_dir/temp.2.hmm -o $target_out_dir/temp.2.hmm.log $scaffold_dir/$scaffold/hmms/$clustering_method/$ortho_id.hmm $target_out_dir/transcripts.cleaned.pep >/dev/null 2>/dev/null";								
+		    system "$hmmsearch -E 1e-5 --cpu $num_threads --noali --tblout $target_out_dir/temp.2.hmm -o $target_out_dir/temp.2.hmm.log $scaffold_dir/hmms/$clustering_method/$ortho_id.hmm $target_out_dir/transcripts.cleaned.pep >/dev/null 2>/dev/null";								
 		}	
 		# compute transcript orthogroup coverage
 		$hits = 0;
@@ -656,7 +657,7 @@ sub targeted_gene_family_assembly {
 			system "rm -r $target_out_dir";
 			next;
 		}
-		system "$mafft --add $target_out_dir/temp.2.hmm.pep $scaffold_dir/$scaffold/alns/$clustering_method/$ortho_id.aln > $target_out_dir/temp.2.hmm.pep.aln 2>/dev/null";
+		system "$mafft --add $target_out_dir/temp.2.hmm.pep $scaffold_dir/alns/$clustering_method/$ortho_id.aln > $target_out_dir/temp.2.hmm.pep.aln 2>/dev/null";
 		unless ($gap_trimming) { $gap_trimming = 0.1; } 
 		system "$trimal -in $target_out_dir/temp.2.hmm.pep.aln -out $target_out_dir/temp.2.hmm.pep.aln.trim -gt $gap_trimming >/dev/null 2>/dev/null";
 		open(IN, "$target_out_dir/temp.2.hmm.pep.aln.trim") or die "can't open $target_out_dir/temp.2.hmm.pep.aln.trim file\n";

--- a/pipelines/GeneFamilyClassifier
+++ b/pipelines/GeneFamilyClassifier
@@ -6,6 +6,8 @@
 
 use strict;
 use warnings;
+use File::Spec;
+use File::Basename;
 use Getopt::Long qw(:config no_ignore_case);
 use FindBin;
 
@@ -38,9 +40,6 @@ my $usage = <<__EOUSAGE__;
 #
 # # # # # # # # # # # # # # # # # # 
 #  Others Options:
-#
-#  --scaffold_dir <string>         : Optional directory path containing the scaffolds datasets
-#                                    Default: $home/data
 #
 #  --num_threads <int>             : number of threads (CPUs) to used for HMMScan, BLASTP, and MAFFT
 #                                    Default: 1 
@@ -109,8 +108,11 @@ while (<IN>) {
 }
 close IN;
 
-if (!($scaffold_dir)) {
-    $scaffold_dir = "$home/data"
+if (File::Spec->file_name_is_absolute($scaffold)) {
+	$scaffold_dir = $scaffold;
+	$scaffold = basename($scaffold);
+} else {
+	$scaffold_dir = "$home/data/$scaffold";
 }
 
 my $blastp = $utilies{'blastp'};
@@ -179,14 +181,14 @@ sub sort_sequences {
 	if ( (!$super_orthogroups) or ($super_orthogroups ne "min_evalue") or ($super_orthogroups ne "avg_evalue") ) { $super_orthogroups = "min_evalue" } 
 	if ( ($classifier eq "blastp") or ($classifier eq "both") ) {
 		print "-- ".localtime()." - Running BLASTP\n\n";
-		system "$blastp -db_soft_mask 21 -outfmt 6 -evalue 1e-5 -num_threads $num_threads -query $proteins -db $scaffold_dir/$scaffold/db/blast/$method -out $dirname/proteins.blastp.$scaffold  >/dev/null 2>/dev/null";
+		system "$blastp -db_soft_mask 21 -outfmt 6 -evalue 1e-5 -num_threads $num_threads -query $proteins -db $scaffold_dir/db/blast/$method -out $dirname/proteins.blastp.$scaffold  >/dev/null 2>/dev/null";
 		print "-- ".localtime()." - Getting best BLASTP hits\n\n";
 		my $results = "proteins.blastp.$scaffold";
 		get_best_blastp_orthos ( $classifier, $results, $dirname, $scaffold, $method, $super_orthogroups, $home );
 	}
 	if ( ($classifier eq "hmmscan") or ($classifier eq "both") ) {
 		print "-- ".localtime()." - Running HMMScan\n\n";
-		system "$hmmscan -E 1e-5 --cpu $num_threads --noali --tblout $dirname/proteins.hmmscan.$scaffold -o $dirname/hmmscan.log $scaffold_dir/$scaffold/db/hmm/$method $proteins >/dev/null 2>/dev/null";
+		system "$hmmscan -E 1e-5 --cpu $num_threads --noali --tblout $dirname/proteins.hmmscan.$scaffold -o $dirname/hmmscan.log $scaffold_dir/db/hmm/$method $proteins >/dev/null 2>/dev/null";
 		print "-- ".localtime()." - Getting best HMMScan hits\n\n";
 		my $results = "proteins.hmmscan.$scaffold";
 		get_best_hmmscan_orthos ( $classifier, $results, $dirname, $scaffold, $method, $super_orthogroups, $home );
@@ -213,7 +215,7 @@ sub  get_best_blastp_orthos {
     	}
 	} 
 	close IN;
-	open (IN, "$scaffold_dir/$scaffold/annot/$method.list") or die "can't open $scaffold_dir/$scaffold/annot/$method.list file\n";
+	open (IN, "$scaffold_dir/annot/$method.list") or die "can't open $scaffold_dir/annot/$method.list file\n";
 	while (<IN>) {
 		chomp;
 		my @F=split(/\t/, $_);
@@ -313,7 +315,7 @@ sub get_annot_summary {
 	my ( $orthogroup_assignment, $dirname, $scaffold, $method, $super_orthogroups, $home ) = @_;
 	my %annot;
 	open (OUT, ">$dirname/$orthogroup_assignment.summary") or die "can't open $dirname/$orthogroup_assignment.summary file\n";	
-	open (IN, "$scaffold_dir/$scaffold/annot/$method.$super_orthogroups.summary") or die "can't open $scaffold_dir/$scaffold/annot/$method.$super_orthogroups.summary file\n";
+	open (IN, "$scaffold_dir/annot/$method.$super_orthogroups.summary") or die "can't open $scaffold_dir/annot/$method.$super_orthogroups.summary file\n";
 	while (<IN>) {
 		chomp;
 		if ($_ =~ /^Orthogroup/) { print OUT "Gene ID\t$_\n"; next; }

--- a/pipelines/PhylogenomicsAnalysis
+++ b/pipelines/PhylogenomicsAnalysis
@@ -6,6 +6,8 @@
 
 use strict;
 use warnings;
+use File::Spec;
+use File::Basename;
 use Getopt::Long qw(:config no_ignore_case);
 use FindBin;
 
@@ -89,9 +91,6 @@ my $usage = <<__EOUSAGE__;
 #
 # # # # # # # # # # # # # # # # # # 
 #  Others Options:
-#
-#  --scaffold_dir <string>         : Optional directory path containing the scaffolds datasets
-#                                    Default: $home/data
 #
 #  --num_threads <int>             : number of threads (CPUs) to assign to external utilities (MAFFT, PASTA, and RAxML)
 #                                    Default: 1 
@@ -180,8 +179,11 @@ while (<IN>) {
 }
 close IN;
 
-if (!($scaffold_dir)) {
-    $scaffold_dir = "$home/data"
+if (File::Spec->file_name_is_absolute($scaffold)) {
+	$scaffold_dir = $scaffold;
+	$scaffold = basename($scaffold);
+} else {
+	$scaffold_dir = "$home/data/$scaffold";
 }
 
 if ($pasta_script_path) {
@@ -289,9 +291,9 @@ sub get_orthogroup_fasta {
 		die "Exiting...!\nOrthogroup classification protein and CDS fasta files not equivalent in $orthogroup_faa directory\n\n";
 	}	
 	foreach my $ortho_id (keys %pep) { 
-		system "cat $scaffold_dir/$scaffold/fasta/$method/$ortho_id.faa $orthogroup_faa/$ortho_id.faa > $orthogroups_fasta/$ortho_id.faa";
+		system "cat $scaffold_dir/fasta/$method/$ortho_id.faa $orthogroup_faa/$ortho_id.faa > $orthogroups_fasta/$ortho_id.faa";
 		if ($orthogroup_fna and $cds{$ortho_id}) {
-			system "cat $scaffold_dir/$scaffold/fasta/$method/$ortho_id.fna $orthogroup_faa/$ortho_id.fna > $orthogroups_fasta/$ortho_id.fna";
+			system "cat $scaffold_dir/fasta/$method/$ortho_id.fna $orthogroup_faa/$ortho_id.fna > $orthogroups_fasta/$ortho_id.fna";
 		}
 	} 	
 }
@@ -317,7 +319,7 @@ sub create_orthogroup_alignments {
 			system "$mafft --maxiterate 1000 --thread $num_threads --localpair $orthogroups_fasta/$ortho_id.faa > $orthogroups_aln/$ortho_id.faa.aln 2>/dev/null"; 
 		}
 		if ($add_alignments) {
-			system "$mafft --add $orthogroup_faa/$ortho_id.faa $scaffold_dir/$scaffold/alns/$method/$ortho_id.aln > $orthogroups_aln/$ortho_id.faa.aln 2>/dev/null";
+			system "$mafft --add $orthogroup_faa/$ortho_id.faa $scaffold_dir/alns/$method/$ortho_id.aln > $orthogroups_aln/$ortho_id.faa.aln 2>/dev/null";
 		}
 		if ($pasta_alignments) {
 			my $pasta_temp = "$dirname/pasta_temp";


### PR DESCRIPTION
@ewafula This PR eliminates the --scaffold_dir parameter, but allows for the original --scaffold parameter to be either an absolute path to the installed scaffold data or a string like 22Gv1.1, which keeps the initial use of this parameter as it was.  If the parameter value is an absolute path, the pipeline code now splits it as necessary.  This code is backward compatible with your older versions of these pipelines before the optional --scaffold_dir parameter was introduced.