### PR TITLE
Fix for using default singleCopy.config in GeneFamilyClassifier

### DIFF
--- a/pipelines/GeneFamilyClassifier
+++ b/pipelines/GeneFamilyClassifier
@@ -122,7 +122,7 @@ if (!$config_dir || !File::Spec->file_name_is_absolute($config_dir)) {
 	$config_dir = "$home/config";
 }
 
-if ($single_copy_custom == "default") {
+if ($single_copy_custom eq "default") {
     $single_copy_custom = "$config_dir/$scaffold.singleCopy.config";
 }
 


### PR DESCRIPTION
@ewafula Both of the bugs we saw when using the GeneFamilyClassifier tool in Galaxy are fixed.