### PR TITLE
Better fix for handling default singleCopy.config

### DIFF
--- a/pipelines/GeneFamilyClassifier
+++ b/pipelines/GeneFamilyClassifier
@@ -122,7 +122,7 @@ if (!$config_dir || !File::Spec->file_name_is_absolute($config_dir)) {
 	$config_dir = "$home/config";
 }
 
-if ($single_copy_custom eq "default") {
+if ($single_copy_custom && $single_copy_custom eq "default") {
     $single_copy_custom = "$config_dir/$scaffold.singleCopy.config";
 }
 


### PR DESCRIPTION
@ewafula This better fix will not throw an exception if the --single_copy_custom parameter is not used.