### PR TITLE
Use inline text if --codeml_ctl_file is not used

### DIFF
--- a/pipelines/KaKsAnalysis
+++ b/pipelines/KaKsAnalysis
@@ -158,7 +158,51 @@ if ( $fit_components and !$num_of_components ) {
 # defaults
 if (!$min_coverage) { $min_coverage = 0.5; }
 if (!$num_threads) { $num_threads = 1; }
-if (!$codeml_ctl_file) { $codeml_ctl_file = "$config_dir/codeml.ctl.args" }
+if (!$codeml_ctl_file) {($codeml_ctl_file = qq{
+        noisy = 0  * 0,1,2,3,9: how much rubbish on the screen
+      verbose = 0  * 0: concise; 1: detailed, 2: too much
+      runmode = -2  * 0: user tree;  1: semi-automatic;  2: automatic
+                   * 3: StepwiseAddition; (4,5):PerturbationNNI; -2: pairwise
+
+      seqtype = 1  * 1:codons; 2:AAs; 3:codons-->AAs
+    CodonFreq = 2  * 0:1/61 each, 1:F1X4, 2:F3X4, 3:codon table
+       aaDist = 0  * 0:equal, +:geometric; -:linear, 1-6:G1974,Miyata,c,p,v,a
+
+        model = 1  * 0:one, 1:b, 2:2 or more dN/dS ratios for branches
+      NSsites = 0  * 0:one w;1:neutral;2:selection; 3:discrete;4:freqs;
+                   * 5:gamma;6:2gamma;7:beta;8:beta&w;9:beta&gamma;
+                   * 10:beta&gamma+1; 11:beta&normal>1; 12:0&2normal>1;
+                   * 13:3normal>0
+
+        icode = 0  * 0:universal code; 1:mammalian mt; 2-10:see below
+        Mgene = 0  * 0:rates, 1:separate; 2:diff pi, 3:diff kapa, 4:all diff
+
+    fix_kappa = 0  * 1: kappa fixed, 0: kappa to be estimated
+        kappa = 2  * initial or fixed kappa
+    fix_omega = 0  * 1: omega or omega_1 fixed, 0: estimate
+        omega = 2  * initial or fixed omega, for codons
+
+    fix_alpha = 1  * 0: estimate gamma shape parameter; 1: fix it at alpha
+        alpha = 0. * initial or fixed alpha, 0:infinity (constant rate)
+       Malpha = 0  * different alphas for genes
+        ncatG = 2  * # of categories in dG of NSsites models
+
+        clock = 0   * 0:no clock, 1:global clock; 2:local clock; 3:TipDate
+        getSE = 0  * 0: don't want them, 1: want S.E.s of estimates
+ RateAncestor = 0 * (0,1,2): rates (alpha>0) or ancestral states (1 or 2)
+
+* Genetic codes: 0:universal, 1:mammalian mt., 2:yeast mt., 3:mold mt.,
+* 4: invertebrate mt., 5: ciliate nuclear, 6: echinoderm mt.,
+* 7: euplotid mt., 8: alternative yeast nu. 9: ascidian mt.,
+* 10: blepharisma nu.
+* These codes correspond to transl_table 1 to 11 of GENEBANK.
+
+   Small_Diff = .5e-6
+*    cleandata = 1  * remove sites with ambiguity data (1:yes, 0:no)?
+*        ndata = 2
+*  fix_blength = -1  * 0: ignore, -1: random, 1: initial, 2: fixed
+        method = 1   * 0: simultaneous; 1: one branch at a time})
+}
 
 print "\n";
 print localtime()." - Starting nonsynonymous (ka) and synonymous (ks) analysis\n\n";


### PR DESCRIPTION
@ewafula This will allow us to eliminate the use of the scaffold selector on the Galaxy wrapper for KaKs as long as the PAML codeml file can always look like this, no matter the version of the selected scaffold.  Please do not merge this PR until we have a chance to discuss it.  This is possible a first step.  I need to discuss with you your use of the plantTribes.config file as well, and based on that discussion we make make another change.